### PR TITLE
Make RPM installations idempotent by using 'rpm -U' instead of 'rpm -i'

### DIFF
--- a/agent-install/linux/yd-agent-installer.sh
+++ b/agent-install/linux/yd-agent-installer.sh
@@ -83,7 +83,7 @@ if [[ $PACKAGE == "deb" ]]; then
   export DEBIAN_FRONTEND=noninteractive
   apt-get install -y -o DPkg::Lock::Timeout=-1 "$PACKAGE_FILE" &> /dev/null
 elif [[ $PACKAGE == "rpm" ]]; then
-  rpm -i "$PACKAGE_FILE" &> /dev/null
+  rpm -U --test "$PACKAGE_FILE" && rpm -U "$PACKAGE_FILE" &> /dev/null
 fi
 
 yd_log "Agent package installation complete ... removing package"


### PR DESCRIPTION
The RPM installation command `rpm -i` will fail if the package is already installed. This change uses `rpm -U` instead, . This will:

- test if this version of the package is already installed
- ignore the package and proceed, if the current version is already installed
- upgrade the package if an older version is currently installed

Tested on Rocky Linux 9.